### PR TITLE
#161771477 Power individual attendant sales page

### DIFF
--- a/UI/attendantsalesrecords.html
+++ b/UI/attendantsalesrecords.html
@@ -39,14 +39,15 @@
   </div>
 
     <table>
+	
       <caption>Attendant Sale Records</caption>
       <thead>
         <tr>
-          <th scope="col">Product Name</th>
-          <th scope="col">Quantity</th>
-          <th scope="col">Price</th>
-          <th scope="col">Total</th>
-          <th scope="col">Category</th>
+          <th scope="col">Product ID</th>
+		  <th scope="col">Sales ID</th>
+          <th scope="col">Sold Quantity</th>
+          <th scope="col">Product Price</th>
+		  <th scope="col">User ID</th>
         </tr>
       </thead>
       <tfoot>
@@ -54,37 +55,10 @@
           <td colspan="5">Individual Sale Record.</td>
         </tr>
       </tfoot>
-      <tbody>
-        <tr>
-          <th scope="row">Dining Room Chair</th>
-          <td>2</td>
-          <td>Kshs 1299</td>
-          <td>Kshs 2598</td>
-          <td>Furniture</td>
-        </tr>
-        <tr>
-          <th scope="row">Couch</th>
-          <td>1</td>
-          <td>Kshs 1299</td>
-          <td>Kshs 1299</td>
-          <td>Furniture </td>
-        </tr>
-        <tr>
-          <th scope="row">Seta Mattress</th>
-          <td>3</td>
-          <td>Kshs 1899</td>
-          <td>Kshs 5697</td>
-          <td>Beddings</td>
-        </tr>
-        <tr>
-          <th scope="row">Valon Petroleum Jelly</th>
-          <td>3</td>
-          <td>Kshs 49</td>
-          <td>Kshs 147</td>
-          <td> Cosmetics </td>
-        </tr>
+      <tbody id= "tablebody">
+        
       </tbody>
     </table>
-
   </body>
+   <script src="js/viewallsales.js"></script>
 </html>

--- a/UI/js/logout.js
+++ b/UI/js/logout.js
@@ -1,4 +1,3 @@
 function logout(){
 	localStorage.clear()
-
 }

--- a/UI/js/viewallsales.js
+++ b/UI/js/viewallsales.js
@@ -1,0 +1,42 @@
+const token = localStorage.getItem('token')
+const access_token = "Bearer " + token
+if (token === null){
+  alert("Please login to view the sales page!")
+}
+
+//Getting our sales from the REST API
+fetch("https://store-manager-api-app-v2.herokuapp.com/api/v2/sales",{
+headers: {
+	'Content-Type': 'application/json',
+	'Access-Control-Allow-Origin':'*',
+	'Access-Control-Request-Method': '*',
+	'Authorization': access_token
+},
+method:"GET",
+mode: "cors",
+})
+.then(function(response)
+{
+	return response.json()
+	
+	})
+.then((data) => {
+	console.log(data)
+	let output = ''
+	data["Sale records"].forEach(function(sale){
+	output+=`
+	    <tr>
+          <th scope="row">${sale.product_id}</th>
+          <td>${sale.sales_id}</td>
+          <td>${sale.sales_quantity}</td>
+          <td>${sale.prod_price}</td>
+          <td>${sale.user_id}</td>
+        </tr>
+	`
+	;
+	
+	});
+	document.getElementById('tablebody').innerHTML = output;
+	
+})
+


### PR DESCRIPTION
#### What does this PR do?
Powers the sales page of an individual attendant to display their sales records
#### Description of Task to be completed?
Power sales page UI template using fetch api and vanilla js
#### How should this be manually tested?
1. Clone the repo
2. Checkout to the current branch: `ft-individual-attendant-sales`
3. Login via the `login.html` page
4. Use the following attendant credentials to sign in:
`email`: `abby@gmail.com`
`password`:`abby1234`
5. Navigate to the `View Sales` tab  on the side nav
6. The page displays the sales of the logged in user
#### Any background context you want to provide?
Fetch API works asynchronously with the REST API endpoint(GET `/api/v2/sales`) to fetch the sales records of an individual attendant
#### What are the relevant pivotal tracker stories?
#161771477
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/23090268/48310442-3ca87080-e5a0-11e8-8094-91a49ee20de6.png)
