### PR TITLE
#161863158 Power all attendants page using vanilla js and fetch api

### DIFF
--- a/UI/attendantprofile.html
+++ b/UI/attendantprofile.html
@@ -38,17 +38,8 @@
     <a href="attendantsalesrecords.html">View Sales</a><br>
     <a href="login.html">Logout</a>
 </div>
-<div class="att-profile">
-<img src="images/avatar-homme.png" alt="Bed" style="width:100%">
-<hr>
-<p>Attendant Name: Allan Mogusu<p><hr>
-<p>Attendant ID: 1234567</p><hr>
-<p>Attendant Email: allanmogusu@1234.com</p><hr>
-<p>Total Sale Records: 500</p><hr>
-<p>Total Number of Products Sold: 1000</p><hr>
-<p>Total worth of goods Sold:Kshs 10,000</p><hr>
-<p><button>View Contact</button></p>
+<div class="product" id="attdetails">
 </div>
-
 </body>
+<script src="js/allattendants.js"></script>
 </html>

--- a/UI/css/main.css
+++ b/UI/css/main.css
@@ -140,6 +140,16 @@ body{
   padding: 2%;
 flex-basis: 16%
 }
+
+.all-att-profile{
+	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  max-width: 340px;
+  margin: auto;
+  text-align: center;
+  font-family: 'Nunito';
+  padding: 2%;
+flex-basis: 16%
+}
 .prod-profile{
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   max-width: 340px;

--- a/UI/js/allattendants.js
+++ b/UI/js/allattendants.js
@@ -1,0 +1,43 @@
+const token = localStorage.getItem('token')
+const access_token = "Bearer " + token
+if (token === null){
+  alert("Please login to view the sales page!")
+}
+
+//Getting attendant details from the rest api
+fetch("https://store-manager-api-app-v2.herokuapp.com/api/v2/auth/users",{
+headers: {
+	'Content-Type': 'application/json',
+	'Access-Control-Allow-Origin':'*',
+	'Access-Control-Request-Method': '*',
+	'Authorization': access_token
+},
+method:"GET",
+mode: "cors",
+})
+.then(function(response)
+{
+	return response.json()
+	
+	})
+.then((data) => {
+	let output = ''
+	data["Users"].forEach(function(user){
+	output+=
+	`
+<div class="card">
+<img src="images/avatar-homme.png" alt="attendant image" style="width:100%">
+<hr>
+<p>Attendant ID: ${user.user_id} </p><hr>
+<p>Attendant Email: ${user.email} </p><hr>
+<p><button>Make Admin</button></p>
+</div>
+
+	`
+	;
+	
+	});
+	document.getElementById('attdetails').innerHTML = output;
+	
+})
+


### PR DESCRIPTION
#### What does this PR do?
Powers the attendants' page to display all attendants of the system
#### Description of Task to be completed?
Admin should be able to view all attendants of the system, hence the powering of the UI of the attendants' page using fetch api and vanilla js
#### How should this be manually tested?
1. Clone the repo
2. Checkout to the current branch: `ft-all-attendants-page`
3. Login with the admin credentials:
`email`: `allan@gmail.com`
`password`: `allangmailcompany`
4. Navigate to the `View Profile` tab
5. All attendant users are displayed
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#161863158
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/23090268/48311132-42a44e80-e5ac-11e8-9183-0a32d94550b1.png)