### PR TITLE
#161863160 Powered single attendant page using fetch api and vanilla js

### DIFF
--- a/UI/attendantprofile.html
+++ b/UI/attendantprofile.html
@@ -42,4 +42,5 @@
 </div>
 </body>
 <script src="js/allattendants.js"></script>
+<script src="js/singleattendant.js"></script>
 </html>

--- a/UI/css/main.css
+++ b/UI/css/main.css
@@ -133,11 +133,12 @@ body{
 }
 .att-profile{
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  max-width: 340px;
+  max-width: 360px;
   margin: auto;
   text-align: center;
   font-family: 'Nunito';
   padding: 2%;
+  flex-grow: 1;
 flex-basis: 16%
 }
 

--- a/UI/index.html
+++ b/UI/index.html
@@ -42,7 +42,6 @@
   <div id="main">
     <nav class="product-filter">
   <h1>Products</h1>
-  <input type="search" id ="search" placeholder="Search...">
   <div class="sort">
     <div class="collection-sort">
       <label>Filter by:</label>

--- a/UI/js/singleattendant.js
+++ b/UI/js/singleattendant.js
@@ -1,0 +1,39 @@
+if (token === null){
+  alert("Please login to view the sales page!")
+}
+
+//Getting attendant details from the rest api
+fetch("https://store-manager-api-app-v2.herokuapp.com/api/v2/auth/users",{
+headers: {
+	'Content-Type': 'application/json',
+	'Access-Control-Allow-Origin':'*',
+	'Access-Control-Request-Method': '*',
+	'Authorization': access_token
+},
+method:"GET",
+mode: "cors",
+})
+.then(function(response)
+{
+	return response.json()
+	
+	})
+.then((data) => {
+	let output = ''
+	output+=
+	`
+<div class="att-profile">
+<img src="images/avatar-homme.png" alt="attendant image" style="width:100%">
+<hr>
+<p>Attendant ID: ${data["User Profile"].user_id} </p><hr>
+<p>Attendant Email: ${data["User Profile"].email} </p><hr>
+<p><button>Make Admin</button></p>
+</div>
+
+	`
+	;
+	
+	document.getElementById('attdetails').innerHTML = output;
+	
+})
+


### PR DESCRIPTION
#### What does this PR do?
Powers the single attendant page using fetch api and vanilla js
#### Description of Task to be completed?
The logged in attendant should be able to view their details, hence, the powering of the attendant profile page using fetch api and vanilla js
#### How should this be manually tested?
1. Clone the repo
2. Checkout to the current branch: `ft-single-attendant-page`
3. Login via the `login.html` page with the following credentials:
`email`: `abby@gmail.com`
`password`: `abby1234`
4. Navigate to the `View Profile` tab
5. The page should display the details of the current logged in user
#### Any background context you want to provide?
fetch API works asynchronously with the REST API endpoint(`GET /api/v2/auth/users`) to fetch the details of the currently logged in user
#### What are the relevant pivotal tracker stories?
#161863160
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/23090268/48311969-cebc7300-e5b8-11e8-9bf6-fafc3a7236b3.png)
