### PR TITLE
#161863152 Power upgrade attendant to admin page using vanilla js and fetch api

### DIFF
--- a/UI/js/allattendants.js
+++ b/UI/js/allattendants.js
@@ -25,13 +25,17 @@ mode: "cors",
 	data["Users"].forEach(function(user){
 	output+=
 	`
+<form action="makeadmin.html">
 <div class="card">
 <img src="images/avatar-homme.png" alt="attendant image" style="width:100%">
 <hr>
+<input type="hidden" name="attendant_email" id="attendant_email" value=${user.email}>
 <p>Attendant ID: ${user.user_id} </p><hr>
 <p>Attendant Email: ${user.email} </p><hr>
-<p><button>Make Admin</button></p>
+<p> Role: ${user.role} </p><hr>
+<p><button type="submit">Make Admin</button></p>
 </div>
+</form>
 
 	`
 	;

--- a/UI/js/makeadmin.js
+++ b/UI/js/makeadmin.js
@@ -1,0 +1,52 @@
+//add button click event listener to the submit button
+var submitbtn = document.getElementById("btnmakeadmin")
+if(submitbtn){
+submitbtn.addEventListener('click', createSale);	
+} 
+let qString = window.location.search;
+var urlParams = new URLSearchParams(qString);
+var email = urlParams.get('attendant_email');
+//set textbox value to passed email
+document.getElementById("email").value = email;
+//call back function
+function createSale(e){
+	e.preventDefault()
+	var data = 
+		{
+			email:email
+		};
+	
+	
+	let token = localStorage.getItem("token");
+	access_token = "Bearer "+token;
+	if (token === null){
+  alert("Please login with your attendant credentials")
+	window.location.href = "./login.html"
+   }
+	fetch('https://store-manager-api-app-v2.herokuapp.com/api/v2/auth/make-admin', {
+		method: "PUT",
+		headers: {
+		'Content-Type': 'application/json',
+	    'Access-Control-Allow-Origin':'*',
+	    'Access-Control-Request-Method': '*',
+	    'Authorization': access_token
+		},
+		    
+	mode:"cors",
+	body: JSON.stringify(data)
+	})
+	.then((response) => response.json())
+	.then(function (response) {
+		
+		if (response.Message === "Attendant made admin successfully!"){
+			// redirect to index page
+            alert(response.Message)
+			window.location.href = './attendantprofile.html'
+		}
+		else{
+            alert(response.Message)
+		}
+
+	
+	})
+}

--- a/UI/js/singleattendant.js
+++ b/UI/js/singleattendant.js
@@ -27,7 +27,6 @@ mode: "cors",
 <hr>
 <p>Attendant ID: ${data["User Profile"].user_id} </p><hr>
 <p>Attendant Email: ${data["User Profile"].email} </p><hr>
-<p><button>Make Admin</button></p>
 </div>
 
 	`

--- a/UI/makeadmin.html
+++ b/UI/makeadmin.html
@@ -1,0 +1,52 @@
+<!Doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" type="text/css" href="css/registration.css">
+<link href='https://fonts.googleapis.com/css?family=Nunito:400,300' rel='stylesheet' type='text/css'>
+<script type="text/javascript" src="js/main.js"></script>
+<title>Create a Sale</title>
+</head>
+<body>
+  <nav class="navbar">
+    <span class="open-slide">
+      <a href="#" onclick="openSlideMenu()">
+        <svg width="30" height="30">
+            <path d="M0,5 30,5" stroke="#fff" stroke-width="5"/>
+            <path d="M0,14 30,14" stroke="#fff" stroke-width="5"/>
+            <path d="M0,23 30,23" stroke="#fff" stroke-width="5"/>
+        </svg>
+      </a>
+    </span>
+    <ul class="navbar-nav">
+      <li><a href="index.html">All Products</a></li>
+      <li><a href="allsalerecords.html">Sales Records</a></li>
+      <li><a href="attendantprofile.html">View Profile</a></li>
+      <li><a href="crudproduct.html">Create Product</a></li>
+      <li><a href="individualprodetails.html">Product Information</a></li>
+      <li><a href="login.html">Logout</a></li>
+    </ul>
+  </nav>
+
+<div id="side-menu" class="side-nav">
+    <a href="#" class="btn-close" onclick="closeSlideMenu()">&times;</a>
+    <a href="addprodcategory.html">Update Product</a><br>
+    <a href="register.html">Add Attendant</a><br>
+    <a href="attendantsalesrecords.html">View Sales</a><br>
+    <a href="login.html">Logout</a>
+</div>
+<form>
+  <div class="container" id="main">
+    <h1>Make an attendant user an admin</h1>
+    <p>Please fill in this form to upgrade an attendant user to admin</p>
+    <hr>
+    <label for="email" ><b>Attendant Email</b></label>
+    <input type="text" id="email" placeholder="Enter the email of the user" name="email" required>
+    <hr>
+    <button type="submit" class="registerbtn" id="btnmakeadmin">Make Admin</button>
+  </div>
+  <script src="js/makeadmin.js"></script>
+</form>
+</body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
Powers the make an attendant admin page using vanilla js and fetch api
#### Description of Task to be completed?
The admin can give attendant admin rights, by upgrading them to admin users. This requires powering of the UI templates using the fetch api
#### How should this be manually tested?
1. Clone the repo
2. In the cloned repo, checkout to the `ft-make-admin-page` branch
3. Log in as admin user with the credentials:
`email`: `allan@gmail.com`
`password`: `allangmailcompany`
4. In the `View Profile` page click on the `make admin` button of any attendant user displayed
5. In the page you're redirected to click the `make admin` button
#### Any background context you want to provide?
The fetch API works asynchronously with the REST API endpoint(`PUT /api/v2/auth/make-admin`) to upgrade attendant to admin role
#### What are the relevant pivotal tracker stories?
#161863152
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/23090268/48312674-7ccd1a80-e5c3-11e8-8614-eb9fde4911cd.png)

#### Questions: